### PR TITLE
文字エスケープを実施

### DIFF
--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -25,7 +25,7 @@ import Layout from '../../layouts/Layout.astro';
 				<li>
 					<p>
 						<code>src/pages/subdomains/index.astro</code>を開き、欲しいドメインとその概要をリストに追記してください。
-						例: <code><li><p><a href="https://link.tsukuba.dev">links.tsukuba.dev</a>: 学内組織へのリンクや学生が作成したサービスへのリンク集。</p></li><code>
+						例: <code>&lt;li&gt;&lt;p&gt;&lt;a href="https://link.tsukuba.dev"&gt;links.tsukuba.dev&lt;/a&gt;: 学内組織へのリンクや学生が作成したサービスへのリンク集。&lt;/p&gt;&lt;/li&gt;</code>
 					</p>
 				</li>
 				<li>

--- a/src/pages/subdomains/index.astro
+++ b/src/pages/subdomains/index.astro
@@ -9,7 +9,7 @@ import Layout from '../../layouts/Layout.astro';
             <div>
                 <p>tsukuba.devは筑波大学の学生のために一定の条件を課してドメインを貸し出しています。このページではその一覧を掲示しています。</p>
                 <ul>
-                    <li><p><a href="https://link.tsukuba.dev">links.tsukuba.dev</a>: 学内組織へのリンクや学生が作成したサービスへのリンク集。</p></li>
+                    <li><p><a href="https://link.tsukuba.dev">link.tsukuba.dev</a>: 学内組織へのリンクや学生が作成したサービスへのリンク集。</p></li>
                 </ul>
             </div>
 			


### PR DESCRIPTION
ページが正しく表示されておらず、その原因を調査したところ`<code>`内に書かれていた例中の文字がエスケープされていなかったことが原因であることが分かりました。そのため例中の文字のうち必要なものをエスケープしました。