### PR TITLE
`mi.tsukuba.dev`を追加

### DIFF
--- a/src/pages/subdomains/index.astro
+++ b/src/pages/subdomains/index.astro
@@ -10,6 +10,7 @@ import Layout from '../../layouts/Layout.astro';
                 <p>tsukuba.devは筑波大学の学生のために一定の条件を課してドメインを貸し出しています。このページではその一覧を掲示しています。</p>
                 <ul>
                     <li><p><a href="https://link.tsukuba.dev">link.tsukuba.dev</a>: 学内組織へのリンクや学生が作成したサービスへのリンク集。</p></li>
+                    <li><p><a href="https://mi.tsukuba.dev">mi.tsukuba.dev</a>: UNTIL.等関係者のためのMisskeyサーバー。</p></li>
                 </ul>
             </div>
 			


### PR DESCRIPTION
## 申請元

UNTIL. 公式
目的: 筑波にいる人向けのMisskeyサーバーです。 このサーバー上で既にアカウントを所持している人か、UNTIL. Discordより招待コードを手に入れていただくことにより登録をしていただくことが出来ます。 あんてぃるすきー（ https://misskey.until.tsukuba.one ）の後継サーバーです。

## 申請する文字列

- `mi.tsukuba.dev`

## チェックリスト

* [x] [ドメイン利用ガイドライン](https://www.tsukuba.dev/guidelines/)を読まれましたか？
* [x] UNTIL. Discordに参加されていらっしゃいますか？
* [x] 申請する文字列は既に利用されていたり、予約されていたりしませんか？