### PR TITLE
vendmap.tsukuba.dev を追加

### DIFF
--- a/src/pages/subdomains/index.astro
+++ b/src/pages/subdomains/index.astro
@@ -11,6 +11,7 @@ import Layout from '../../layouts/Layout.astro';
                 <ul>
                     <li><p><a href="https://link.tsukuba.dev">link.tsukuba.dev</a>: 学内組織へのリンクや学生が作成したサービスへのリンク集。</p></li>
                     <li><p><a href="https://mi.tsukuba.dev">mi.tsukuba.dev</a>: UNTIL.等関係者のためのMisskeyサーバー。</p></li>
+                    <li><p><a href="https://vendmap.tsukuba.dev">https://vendmap.tsukuba.dev</a>: 学内の自動販売機を地図から探すことのできるWebサイト。</p></li>
                 </ul>
             </div>
 			


### PR DESCRIPTION
## 申請元

筑波大学自販機Map（ https://itf-vendingmachine.vercel.app ）という、学内の自動販売機を地図から探すことのできるWebサイトです。

## 申請する文字列

`vendmap.tsukuba.dev`

ただし、今存在するvercelのサブドメインをそのままにtsukuba.devのサブドメインがほしいので、CNAMEレコードとして作成していただきたいです。

参考: https://vercel.com/docs/domains/working-with-domains/add-a-domain

## チェックリスト

* [x] [ドメイン利用ガイドライン](https://www.tsukuba.dev/guidelines/)を読まれましたか？
* [x] UNTIL. Discordに参加されていらっしゃいますか？
* [x] 申請する文字列は既に利用されていたり、予約されていたりしませんか？