### PR TITLE
`ivm.tsukuba.dev`を追加

### DIFF
--- a/src/pages/subdomains/index.astro
+++ b/src/pages/subdomains/index.astro
@@ -9,6 +9,7 @@ import Layout from '../../layouts/Layout.astro';
             <div>
                 <p>tsukuba.devは筑波大学の学生のために一定の条件を課してドメインを貸し出しています。このページではその一覧を掲示しています。</p>
                 <ul>
+                    <li><p><a href="https://ivm.tsukuba.dev">ivm.tsukuba.dev</a>: OSMのデータを加工し、筑波大学筑波キャンパス周辺の地物データがベクターとして得られる。</p></li>
                     <li><p><a href="https://link.tsukuba.dev">link.tsukuba.dev</a>: 学内組織へのリンクや学生が作成したサービスへのリンク集。</p></li>
                     <li><p><a href="https://mi.tsukuba.dev">mi.tsukuba.dev</a>: UNTIL.等関係者のためのMisskeyサーバー。</p></li>
                     <li><p><a href="https://vendmap.tsukuba.dev">vendmap.tsukuba.dev</a>: 学内の自動販売機を地図から探すことのできるWebサイト。</p></li>


### PR DESCRIPTION
## 申請元
Overpass APIを用いて、筑波大学内の地物をすべて落とし、GeoJSON等でネットワーク越しに利活用できるようにするサイト「itf-vectormapdata」を作成しました。これに対してドメインを使用させていただきたいです。

https://github.com/until-tsukuba/itf-vectormapdata

## 申請する文字列
ivm.tsukuba.dev

## チェックリスト
* [x] [ドメイン利用ガイドライン](https://www.tsukuba.dev/guidelines/)を読まれましたか？
* [x] UNTIL. Discordに参加されていらっしゃいますか？
* [x] 申請する文字列は既に利用されていたり、予約されていたりしませんか？